### PR TITLE
Better kill handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2017-08-09  Andrew Burgess  <andrew.burgess@embecosm.com>
 
+	* server/GdbServer.cpp (GdbServer::GdbServer): Add new parameter,
+	initialise member variable.
+	(GdbServer::rspClientRequest): Modify handling of kill packet.
+	* server/GdbServer.h (GdbServer::KillBehaviour): New enum.
+	(GdbServer::GdbServer): Add new parameter.
+	(GdbServer::killBehaviour): New member variable.
+	* server/main.cpp (main): Pass suitable GdbServer::KillBehaviour
+	value to new GdbServer object.
+
+2017-08-09  Andrew Burgess  <andrew.burgess@embecosm.com>
+
 	* server/main.cpp (main): Delete connection.
 
 2017-08-04  Andrew Burgess  <andrew.burgess@embecosm.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-08-09  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* server/main.cpp (main): Delete connection.
+
 2017-08-04  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* server/AbstractConnection.cpp: New file.

--- a/server/GdbServer.cpp
+++ b/server/GdbServer.cpp
@@ -81,10 +81,12 @@ static const int RSP_PKT_SIZE =
 
 GdbServer::GdbServer (AbstractConnection * _conn,
 		      ITarget * _cpu,
-		      TraceFlags * _traceFlags) :
+		      TraceFlags * _traceFlags,
+		      KillBehaviour _killBehaviour) :
   cpu (_cpu),
   traceFlags (_traceFlags),
-  timeout (duration <double>::zero ())
+  timeout (duration <double>::zero ()),
+  killBehaviour (_killBehaviour)
 {
   pkt       = new RspPacket (RSP_PKT_SIZE);
   rsp       = _conn;
@@ -397,7 +399,20 @@ GdbServer::rspClientRequest ()
       return;
 
     case 'k':
-      // Kill request. Do nothing for now.
+      // Kill request.
+      switch (killBehaviour)
+	{
+	case EXIT_ON_KILL:
+	  // Like the 'monitor exit' command this is a bit grotty.  Would
+	  // be better if we could return from gdbserver and have main
+	  // delete everything and exit cleanly that way.
+	  exit (EXIT_SUCCESS);
+	  break;
+
+	case RESET_ON_KILL:
+	  // Shhh! We don't actually reset right now.  Just keep going.
+	  break;
+	}
       return;
 
     case 'm':

--- a/server/GdbServer.h
+++ b/server/GdbServer.h
@@ -51,10 +51,21 @@ class GdbServer
 {
 public:
 
+  /* How should we behave when GDB sends a kill (k) packet?  */
+  enum KillBehaviour
+    {
+      /* Reset the target, but remain alive.  */
+      RESET_ON_KILL,
+
+      /* Stop the target, close the connection and return.  */
+      EXIT_ON_KILL
+    };
+
   // Constructor and destructor
   GdbServer (AbstractConnection * _conn,
 	     ITarget * _cpu,
-	     TraceFlags * _traceFlags);
+	     TraceFlags * _traceFlags,
+	     KillBehaviour _killBehaviour);
   ~GdbServer ();
 
   // Main loop to listen for and service RSP requests.
@@ -113,6 +124,9 @@ private:
 
   //! Timeout for continue.
   std::chrono::duration<double>  timeout;
+
+  //! How to behave when we get a kill (k) packet.
+  KillBehaviour killBehaviour;
 
   // Main RSP request handler
   void  rspClientRequest ();

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -187,6 +187,7 @@ main (int   argc,
 
   // Free memory
 
+  delete  conn;
   delete  gdbServer;
   delete  traceFlags;
   delete  cpu;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -169,17 +169,22 @@ main (int   argc,
     }
 
   AbstractConnection *conn;
+  GdbServer::KillBehaviour killBehaviour;
   if (from_stdin)
-    conn = new StreamConnection (traceFlags);
+    {
+      conn = new StreamConnection (traceFlags);
+      killBehaviour = GdbServer::KillBehaviour::EXIT_ON_KILL;
+    }
   else
     {
       port = atoi (argv[optind]);
       conn = new RspConnection (port, traceFlags);
+      killBehaviour = GdbServer::KillBehaviour::RESET_ON_KILL;
     }
 
   // The RSP server
 
-  GdbServer *gdbServer = new GdbServer (conn, cpu, traceFlags);
+  GdbServer *gdbServer = new GdbServer (conn, cpu, traceFlags, killBehaviour);
 
   // Run the GDB server. If we return, then we have hit some sort of problem.
 


### PR DESCRIPTION
This should resolve the issue with `gdb` pausing for a while during exit when starting a gdbserver using the pipe notation.