### PR TITLE
gdbserver: Fix invalid delete of an object

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-08-15  Andrew Burgess  <andrew.burgess@embecosm.com>
+
+	* server/GdbServerImpl.cpp (GdbServerImpl::GdbServerImpl):
+	Initialise rsp member using initialisation list, not within
+	method body.
+	(GdbServerImpl::~GdbServerImpl): Don't delete rsp member.
+
 2017-08-10  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	Break out trace as a library in its own right to be shared by

--- a/server/GdbServerImpl.cpp
+++ b/server/GdbServerImpl.cpp
@@ -66,11 +66,11 @@ GdbServerImpl::GdbServerImpl (AbstractConnection * _conn,
 			      GdbServer::KillBehaviour _killBehaviour) :
   cpu (_cpu),
   traceFlags (_traceFlags),
+  rsp (_conn),
   timeout (duration <double>::zero ()),
   killBehaviour (_killBehaviour)
 {
   pkt           = new RspPacket (RSP_PKT_SIZE);
-  rsp           = _conn;
   mpHash        = new MpHash ();
   mDisassembler = new Disassembler ();
 
@@ -83,7 +83,6 @@ GdbServerImpl::~GdbServerImpl ()
 {
   delete  mDisassembler;
   delete  mpHash;
-  delete  rsp;
   delete  pkt;
 
 }	// ~GdbServerImpl


### PR DESCRIPTION
The gdbserver was incorrectly trying to delete its connection, which is
not owned by gdbserver.  This was leading to a double delete, and a
segfault.

ChangeLog:

	* server/GdbServerImpl.cpp (GdbServerImpl::GdbServerImpl):
	Initialise rsp member using initialisation list, not within
	method body.
	(GdbServerImpl::~GdbServerImpl): Don't delete rsp member.