### PR TITLE
Match upstream GDB

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2019-05-28  Jeremy Bennett  <jeremy.bennett@embecosm.com>
+
+	* targets/ri5cy/Ri5cyImpl.cpp (Ri5cyImpl::stepInstr)
+	(Ri5cyImpl::runToBreak): If we hit a breakpoint set the PC back to
+	the address of the previous instruction, to match the behavior of
+	upstream GDB.
+
 2018-04-04  Andrew Burgess  <andrew.burgess@embecosm.com>
 
 	* server/GdbServerImpl.cpp (GdbServerImpl::rspSyscallRequest):

--- a/targets/ri5cy/Ri5cyImpl.cpp
+++ b/targets/ri5cy/Ri5cyImpl.cpp
@@ -646,8 +646,11 @@ Ri5cyImpl::stepInstr (duration <double>  timeout)
       if (stoppedAtSyscall ())
         return ITarget::ResumeRes::SYSCALL;
       else
-        // Guess we hit a breakpoint while stepping.
-        return ITarget::ResumeRes::INTERRUPTED;
+	{
+	  // Guess we hit a breakpoint while stepping.
+	  writeRegister (REG_PC, readDebugReg (DBG_PPC));
+	  return ITarget::ResumeRes::INTERRUPTED;
+	}
     }
 
   return  ITarget::ResumeRes::STEPPED;
@@ -716,7 +719,11 @@ Ri5cyImpl::runToBreak (duration <double>  timeout)
   if (stoppedAtSyscall ())
     return ITarget::ResumeRes::SYSCALL;
   else
-    return ITarget::ResumeRes::INTERRUPTED;
+    {
+      // Guess we stopped at a breakpoint
+      writeRegister (REG_PC, readDebugReg (DBG_PPC));
+      return ITarget::ResumeRes::INTERRUPTED;
+    }
 }	// Ri5cyImpl::runToBreak ()
 
 


### PR DESCRIPTION
ChangeLog:

	* targets/ri5cy/Ri5cyImpl.cpp (Ri5cyImpl::stepInstr)
	(Ri5cyImpl::runToBreak): If we hit a breakpoint set the PC back to
	the address of the previous instruction, to match the behavior of
	upstream GDB.