### PR TITLE
Fix format string specifiers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2019-09-16  Maxim Blinov  <maxim.blinov@embecosm.com>
+
+	* server/GdbServerImpl.cpp (GdbServerImpl::rspInsertMatchpoint)
+	(GdbServerImpl::rspRemoveMatchpoint): Change erroneous
+	literal 'one' numeral to literal 'l' character in format string.
+
 2019-05-28  Jeremy Bennett  <jeremy.bennett@embecosm.com>
 
 	* targets/ri5cy/Ri5cyImpl.cpp (Ri5cyImpl::stepInstr)

--- a/server/GdbServerImpl.cpp
+++ b/server/GdbServerImpl.cpp
@@ -1477,7 +1477,7 @@ GdbServerImpl::rspRemoveMatchpoint ()
 
   // Break out the instruction
   string ui32Fmt = SCNx32;
-  string fmt = "z%1d,%" + ui32Fmt + ",%1d";
+  string fmt = "z%ld,%" + ui32Fmt + ",%ld";
   if (3 != sscanf (pkt->data, fmt.c_str(), (int *)&type, &addr, &len))
     {
       cerr << "Warning: RSP matchpoint deletion request not "
@@ -1657,7 +1657,7 @@ GdbServerImpl::rspInsertMatchpoint ()
 
   // Break out the instruction
   string ui32Fmt = SCNx32;
-  string fmt = "Z%1d,%" + ui32Fmt + ",%1d";
+  string fmt = "Z%ld,%" + ui32Fmt + ",%ld";
   if (3 != sscanf (pkt->data, fmt.c_str(), (int *)&type, &addr, &len))
     {
       cerr << "Warning: RSP matchpoint insertion request not "


### PR DESCRIPTION
Format strings contained the literal digit '1' instead of the long 'l'
specifier. Compiler didn't catch this because the format string
was held in a variable rather than passed as a constant function
argument.

ChangeLog:

        * server/GdbServerImpl.cpp (GdbServerImpl::rspInsertMatchpoint)
        (GdbServerImpl::rspRemoveMatchpoint): Change erroneous
        literal 'one' numeral to literal 'l' character in format string.